### PR TITLE
fix versioncmp function call

### DIFF
--- a/lib/facter/megacli_legacy.rb
+++ b/lib/facter/megacli_legacy.rb
@@ -10,6 +10,6 @@ Facter.add(:megacli_legacy) do
 
     # Modern version assumed from changelog at
     # http://www.lsi.com/downloads/Public/RAID%20Controllers/RAID%20Controllers%20Common%20Files/Linux%20MegaCLI%208.07.10.txt
-    versioncmp(megacli_version, '8.02.16') == -1
+    Puppet::Util::Package.versioncmp(megacli_version, '8.02.16') == -1
   end
 end


### PR DESCRIPTION
```
Error: Facter: error while resolving custom fact "megacli_legacy":
undefined method `versioncmp' for #<Facter::Util::Resolution:0x00005572870ff3d0>
```