### PR TITLE
Bugfix: use ensure_packages for package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,9 +175,7 @@ class smartd (
     }
   }
 
-  package { $package_name:
-    ensure => $pkg_ensure,
-  }
+  ensure_packages([$package_name], { ensure => $pkg_ensure })
 
   if $srv_manage {
     service { $service_name:


### PR DESCRIPTION
use ensure_packages()-function instead of package-ressource to not conflict with other modules also wanting to install smartmontools.