### PR TITLE
Bugfix: do not bail out on missing smartmontools_version-fact

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,7 +49,7 @@ class smartd::params {
           /10|11|12|13|14|15|16|17|18/ => '/etc/smartd.conf',
           default                      => '/etc/smartmontools/smartd.conf',
         },
-        /RedHat|CentOS|Scientific|SLC|OracleLinux|OEL/ => $::operatingsystemmajrelease ? {
+        /RedHat|CentOS|Scientific|SLC|OracleLinux|OEL|Rocky|AlmaLinux/ => $::operatingsystemmajrelease ? {
           /4|5|6/ => '/etc/smartd.conf',
           default => '/etc/smartmontools/smartd.conf',
         },

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,8 +24,8 @@ class smartd::params {
   $exec_script        = false
   $default_options    = undef
 
-  $version_string = $::smartmontools_version ? {
-    undef   => '0.0',
+  $version_string = defined('$::smartmontools_version') ? {
+    false   => '0.0',
     default => $::smartmontools_version,
   }
 


### PR DESCRIPTION
fixes:
Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Unknown variable: '::smartmontools_version'. (file: /etc/puppetlabs/code/environments/production/modules/smartd/manifests/params.pp, line: 27, column: 21)

Background: using "strict_variables" in puppet will not allow to access undefined variables at all.